### PR TITLE
change return type of apply function

### DIFF
--- a/Setup/Patch/SimpleDataPatch.php
+++ b/Setup/Patch/SimpleDataPatch.php
@@ -58,5 +58,5 @@ abstract class SimpleDataPatch implements DataPatchInterface
     /**
      * Call your patch updates within this function.
      */
-    abstract public function apply(): void;
+    abstract public function apply(): self;
 }


### PR DESCRIPTION
Change return type to match PatchInterface

Return type (void) of method                                           
         SomeDataPatch.php::app  
         ly() should be compatible with return type                             
         ($this(Magento\Framework\Setup\Patch\PatchInterface)) of method        
         Magento\Framework\Setup\Patch\PatchInterface::apply()