### PR TITLE
Correct return type for the apply() method

### DIFF
--- a/Setup/Patch/SimpleDataPatch.php
+++ b/Setup/Patch/SimpleDataPatch.php
@@ -58,5 +58,5 @@ abstract class SimpleDataPatch implements DataPatchInterface
     /**
      * Call your patch updates within this function.
      */
-    abstract public function apply(): self;
+    abstract public function apply(): DataPatchInterface;
 }


### PR DESCRIPTION
Correct return type for the apply() method for PHP 8 compatibility.